### PR TITLE
ci: add Gemini key presence check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,6 @@ jobs:
     env:
       # Expose the Gemini API key to the build step (Vite reads VITE_ prefixed vars at build time)
       VITE_GEMINI_KEY: ${{ secrets.GEMINI_API_KEY }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -29,6 +28,11 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+
+      - name: Check Gemini key
+        run: |
+          node --version
+          node scripts/check_gemini_env.js
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Run scripts/check_gemini_env.js at the start of CI to fail early if GEMINI_API_KEY is not configured.